### PR TITLE
Release v5.2.0

### DIFF
--- a/src/RCParsing/Building/ParserElementBuilder.cs
+++ b/src/RCParsing/Building/ParserElementBuilder.cs
@@ -1389,7 +1389,16 @@ namespace RCParsing.Building
 		{
 			return Token(new EmptyTokenPattern());
 		}
-		
+
+		/// <summary>
+		/// Adds an any character token to the current sequence. It matches any single character, and returns it as intermediate value.
+		/// </summary>
+		/// <returns>Current instance for method chaining.</returns>
+		public T AnyChar()
+		{
+			return Token(new AnyCharTokenPattern());
+		}
+
 		/// <summary>
 		/// Adds a fail token to the current sequence. It always fails.
 		/// </summary>
@@ -2004,6 +2013,21 @@ namespace RCParsing.Building
 		public T TextUntil(params string[] forbidden)
 		{
 			return Token(EscapedTextTokenPattern.CreateUntil(forbidden));
+		}
+
+		// The pizdec
+
+		/// <summary>
+		/// Adds a token pattern that uses an entire parser for matching.
+		/// The parser will be invoked as a token in the current sequence.
+		/// </summary>
+		/// <param name="matchParser">The parser to use for matching.</param>
+		/// <param name="ruleAlias">The alias for the rule to parse. If null, uses the main rule of the parser.</param>
+		/// <param name="tokenAlias">Optional token alias to match instead of a rule. If both this and ruleAlias are null, uses main rule.</param>
+		/// <returns>Current instance for method chaining.</returns>
+		public T Parser(Parser matchParser, string? ruleAlias = null, string? tokenAlias = null)
+		{
+			return Token(new ParserTokenPattern(matchParser, ruleAlias, tokenAlias));
 		}
 	}
 }

--- a/src/RCParsing/ParsedRuleResultBase.cs
+++ b/src/RCParsing/ParsedRuleResultBase.cs
@@ -198,14 +198,16 @@ namespace RCParsing
 		/// </summary>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The intermediate value associated with this AST node.</returns>
-		public T GetIntermediateValue<T>() => (T)IntermediateValue;
+		public T GetIntermediateValue<T>() => IntermediateValue is T res ? res :
+			throw new SemanticException(this, $"Expected an intermediate value of type {typeof(T).Name} but got {IntermediateValue?.GetType().Name ?? "null"}.");
 
 		/// <summary>
 		/// Gets the intermediate value associated with child AST node at the specific index as an instance of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The intermediate value associated with child AST node.</returns>
-		public T GetIntermediateValue<T>(int index) => (T)this[index].IntermediateValue;
+		public T GetIntermediateValue<T>(int index) => this[index].IntermediateValue is T res ? res :
+			throw new SemanticException(this[index], $"Expected an intermediate value of type {typeof(T).Name} but got {IntermediateValue?.GetType().Name ?? "null"}.");
 
 		/// <summary>
 		/// Tries to get the intermediate value associated with this AST node as an instance of type <typeparamref name="T"/>.
@@ -227,40 +229,72 @@ namespace RCParsing
 		/// </summary>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The intermediate value associated with this AST node.</returns>
-		public T ConvertIntermediateValue<T>() => (T)Convert.ChangeType(IntermediateValue, typeof(T));
+		public T ConvertIntermediateValue<T>()
+		{
+			try
+			{
+				return (T)Convert.ChangeType(IntermediateValue, typeof(T));
+			}
+			catch (Exception ex)
+			{
+				throw new SemanticException(this, $"Failed to convert intermediate value to {typeof(T).Name}: {ex.Message}", ex);
+			}
+		}
 
 		/// <summary>
 		/// Gets the intermediate value associated with child AST node at the specific index converted to type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The intermediate value associated with child AST node.</returns>
-		public T ConvertIntermediateValue<T>(int index) => (T)Convert.ChangeType(this[index].IntermediateValue, typeof(T));
+		public T ConvertIntermediateValue<T>(int index)
+		{
+			try
+			{
+				return (T)Convert.ChangeType(this[index].IntermediateValue, typeof(T));
+			}
+			catch (Exception ex)
+			{
+				throw new SemanticException(this[index], $"Failed to convert intermediate value to {typeof(T).Name}: {ex.Message}", ex);
+			}
+		}
 
 		/// <summary>
 		/// Gets the value associated with this AST node as not-null object. If the value is null, throws an exception.
 		/// </summary>
 		/// <returns>The value associated with this AST node.</returns>
-		public object GetValue() => Value ?? throw new InvalidOperationException("ParsedRuleResult.Value is null");
+		public object GetValue() => Value ?? throw new SemanticException(this, "ParsedRuleResult.Value is null");
 
 		/// <summary>
 		/// Gets the value associated with child AST node at the specific index as not-null object. If the value is null, throws an exception.
 		/// </summary>
 		/// <returns>The value associated with child AST node.</returns>
-		public object GetValue(int index) => this[index].Value ?? throw new InvalidOperationException("ParsedRuleResult.Value is null");
+		public object GetValue(int index) => this[index].Value ?? throw new SemanticException(this[index], "ParsedRuleResult[index].Value is null");
 
 		/// <summary>
 		/// Gets the value associated with this AST node as an instance of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The value associated with this AST node.</returns>
-		public T GetValue<T>() => (T)Value;
+		public T GetValue<T>()
+		{
+			var value = Value;
+			return value is T res ? res :
+				throw new SemanticException(this,
+				$"Expected a value of type {typeof(T).Name} but got {value?.GetType().Name ?? "null"}.");
+		}
 
 		/// <summary>
 		/// Gets the value associated with child AST node at the specific index as an instance of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The value associated with child AST node.</returns>
-		public T GetValue<T>(int index) => (T)this[index].Value;
+		public T GetValue<T>(int index)
+		{
+			var value = this[index].Value;
+			return value is T res ? res :
+				throw new SemanticException(this[index],
+				$"Expected a value of type {typeof(T).Name} but got {value?.GetType().Name ?? "null"}.");
+		}
 
 		/// <summary>
 		/// Tries to get the value associated with this AST node as an instance of type <typeparamref name="T"/> or <see langword="default"/> value.
@@ -302,7 +336,17 @@ namespace RCParsing
 		/// </remarks>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The value associated with this AST node.</returns>
-		public T ConvertValue<T>() => (T)Convert.ChangeType(Value, typeof(T));
+		public T ConvertValue<T>()
+		{
+			try
+			{
+				return (T)Convert.ChangeType(Value, typeof(T));
+			}
+			catch (Exception ex)
+			{
+				throw new SemanticException(this, $"Failed to convert value to {typeof(T).Name}: {ex.Message}", ex);
+			}
+		}
 
 		/// <summary>
 		/// Gets the value associated with child AST node at the specific index converted to type <typeparamref name="T"/>.
@@ -312,14 +356,25 @@ namespace RCParsing
 		/// </remarks>
 		/// <typeparam name="T">The type of value to retrieve.</typeparam>
 		/// <returns>The value associated with child AST node.</returns>
-		public T ConvertValue<T>(int index) => (T)Convert.ChangeType(this[index].Value, typeof(T));
+		public T ConvertValue<T>(int index)
+		{
+			try
+			{
+				return (T)Convert.ChangeType(this[index].Value, typeof(T));
+			}
+			catch (Exception ex)
+			{
+				throw new SemanticException(this[index], $"Failed to convert value to {typeof(T).Name}: {ex.Message}", ex);
+			}
+		}
 
 		/// <summary>
 		/// Gets the parsing parameter associated with parser context as an instance of type <typeparamref name="T"/>.
 		/// </summary>
 		/// <typeparam name="T">The type of parsing parameter to retrieve.</typeparam>
 		/// <returns>The parsing parameter associated with the parser context.</returns>
-		public T GetParsingParameter<T>() => (T)ParsingParameter;
+		public T GetParsingParameter<T>() => ParsingParameter is T res ? res :
+			throw new SemanticException(this, $"Expected a parsing parameter of type {typeof(T).Name} but got {ParsingParameter?.GetType().Name ?? "null"}.");
 
 		/// <summary>
 		/// Tries to get the parsing parameter associated with parser context as an instance of type <typeparamref name="T"/> or <see langword="default"/> value.

--- a/src/RCParsing/Parser.findallmatches.cs
+++ b/src/RCParsing/Parser.findallmatches.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using RCParsing.Utils;
 
 namespace RCParsing
 {
@@ -313,7 +314,7 @@ namespace RCParsing
 		/// <returns>The input string with all matches replaced.</returns>
 		public string ReplaceAllMatches(string input, Func<ParsedRuleResultBase, string> replacementSelector)
 		{
-			return ReplaceAllMatches(input, null, replacementSelector);
+			return ReplaceAllMatches(input, parameter: null, replacementSelector);
 		}
 
 		/// <summary>
@@ -357,7 +358,7 @@ namespace RCParsing
 		/// <returns>The input string with all matches replaced.</returns>
 		public string ReplaceAllMatches(string ruleAlias, string input, Func<ParsedRuleResultBase, string> replacementSelector)
 		{
-			return ReplaceAllMatches(ruleAlias, input, fallbackReplacement: null, replacementSelector);
+			return ReplaceAllMatches(ruleAlias, input, parameter: null, replacementSelector);
 		}
 
 		/// <summary>
@@ -400,7 +401,7 @@ namespace RCParsing
 		/// <returns>The input string with all matches replaced.</returns>
 		public string ReplaceAllMatches<T>(string input, Func<T?, string> replacementSelector)
 		{
-			return ReplaceAllMatches(input, null, replacementSelector);
+			return ReplaceAllMatches(input, parameter: null, replacementSelector);
 		}
 
 		/// <summary>
@@ -465,7 +466,7 @@ namespace RCParsing
 
 		/// <summary>
 		/// Splits the input string into substrings by all non-overlapping matches of the specified rule.
-		/// Works similarly to <see cref="System.Text.RegularExpressions.Regex.Split(string)"/>.
+		/// Works similarly to <see cref="Regex.Split(string)"/>.
 		/// </summary>
 		/// <param name="ruleId">The rule ID to use as a delimiter.</param>
 		/// <param name="context">Parser context for the input.</param>
@@ -561,6 +562,402 @@ namespace RCParsing
 				throw new ArgumentException("Invalid rule alias", nameof(ruleAlias));
 
 			return Split(ruleId, context);
+		}
+
+
+
+		/// <summary>
+		/// Splits the input string into segments by all non-overlapping matches of the specified rule.
+		/// Works similarly to <see cref="Regex.Split(string)"/>.
+		/// </summary>
+		/// <param name="ruleId">The rule ID to use as a delimiter.</param>
+		/// <param name="context">Parser context for the input.</param>
+		/// <returns>An enumerable sequence of segments between matches.</returns>
+		internal IEnumerable<StringSegment> SplitSegments(int ruleId, ParserContext context)
+		{
+			if (context.parser != this)
+				throw new InvalidOperationException("Parser context is not associated with this parser.");
+
+			EmitBarriers(ref context);
+
+			var input = context.input;
+
+			// Non-overlapping: the same as ReplaceAllMatches (overlap = false).
+			var matches = FindAllMatches(ruleId, context, GlobalSettings, overlap: false);
+
+			var currentIndex = context.position;
+
+			foreach (var match in matches)
+			{
+				var start = match.startIndex;
+				var length = match.length;
+
+				if (start < currentIndex)
+					continue;
+
+				// Segment before match.
+				yield return new StringSegment(input, currentIndex, start - currentIndex);
+
+				currentIndex = start + length;
+			}
+
+			// Tail after last match.
+			if (currentIndex < context.maxPosition)
+				yield return new StringSegment(input, currentIndex, context.maxPosition - currentIndex);
+		}
+
+		/// <summary>
+		/// Splits the input string into segments by all non-overlapping matches of the main rule.
+		/// Works similarly to <see cref="Regex.Split(string)"/>.
+		/// </summary>
+		/// <param name="input">The input text to split.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of segments between matches.</returns>
+		public IEnumerable<StringSegment> SplitSegments(string input, object? parameter = null)
+		{
+			if (_mainRuleId == -1)
+				throw new InvalidOperationException("Main rule is not set.");
+
+			var context = new ParserContext(this, input, parameter);
+			return SplitSegments(_mainRuleId, context);
+		}
+
+		/// <summary>
+		/// Splits the input represented by the specified context into segments by
+		/// all non-overlapping matches of the main rule.
+		/// </summary>
+		/// <param name="context">The parser context to use for parsing.</param>
+		/// <returns>An enumerable sequence of segments between matches.</returns>
+		public IEnumerable<StringSegment> SplitSegments(ParserContext context)
+		{
+			if (_mainRuleId == -1)
+				throw new InvalidOperationException("Main rule is not set.");
+
+			return SplitSegments(_mainRuleId, context);
+		}
+
+		/// <summary>
+		/// Splits the input string into segments by all non-overlapping matches of the specified rule.
+		/// </summary>
+		/// <param name="ruleAlias">The alias for the parser rule to use as a delimiter.</param>
+		/// <param name="input">The input text to split.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of segments between matches.</returns>
+		public IEnumerable<StringSegment> SplitSegments(string ruleAlias, string input, object? parameter = null)
+		{
+			if (!_rulesAliases.TryGetValue(ruleAlias, out var ruleId))
+				throw new ArgumentException("Invalid rule alias", nameof(ruleAlias));
+
+			var context = new ParserContext(this, input, parameter);
+			return SplitSegments(ruleId, context);
+		}
+
+		/// <summary>
+		/// Splits the input represented by the specified context into segments by
+		/// all non-overlapping matches of the specified rule.
+		/// </summary>
+		/// <param name="ruleAlias">The alias for the parser rule to use as a delimiter.</param>
+		/// <param name="context">The parser context to use for parsing.</param>
+		/// <returns>An enumerable sequence of segments between matches.</returns>
+		public IEnumerable<StringSegment> SplitSegments(string ruleAlias, ParserContext context)
+		{
+			if (!_rulesAliases.TryGetValue(ruleAlias, out var ruleId))
+				throw new ArgumentException("Invalid rule alias", nameof(ruleAlias));
+
+			return SplitSegments(ruleId, context);
+		}
+
+
+
+		/// <summary>
+		/// Finds all matches of target rule, then returns sequence of segments between matches and matches themselves.
+		/// </summary>
+		/// <param name="ruleId">The rule ID to use as a delimiter.</param>
+		/// <param name="context">Parser context for the input.</param>
+		/// <returns>An enumerable sequence of segments between matches and matches.</returns>
+		internal IEnumerable<Or<StringSegment, ParsedRuleResultBase>> Scan(int ruleId, ParserContext context)
+		{
+			if (context.parser != this)
+				throw new InvalidOperationException("Parser context is not associated with this parser.");
+
+			EmitBarriers(ref context);
+
+			var input = context.input;
+
+			// Non-overlapping: the same as ReplaceAllMatches (overlap = false).
+			var matches = FindAllMatches(ruleId, context, GlobalSettings, overlap: false);
+
+			var currentIndex = context.position;
+
+			foreach (var match in matches)
+			{
+				var start = match.startIndex;
+				var length = match.length;
+
+				if (start < currentIndex)
+				{
+					var capturedMatch1 = match;
+					yield return CreateResult(ref context, ref capturedMatch1);
+					continue;
+				}
+
+				// Segment before match.
+				yield return new StringSegment(input, currentIndex, start - currentIndex);
+				currentIndex = start + length;
+
+				var capturedMatch2 = match;
+				yield return CreateResult(ref context, ref capturedMatch2);
+			}
+
+			// Tail after last match.
+			if (currentIndex < context.maxPosition)
+				yield return new StringSegment(input, currentIndex, context.maxPosition - currentIndex);
+		}
+
+		/// <summary>
+		/// Scans the input using the main rule, returning segments between matches and the matches themselves.
+		/// </summary>
+		/// <param name="context">The parser context to use for scanning.</param>
+		/// <returns>An enumerable sequence of segments between matches and matches.</returns>
+		public IEnumerable<Or<StringSegment, ParsedRuleResultBase>> Scan(ParserContext context)
+		{
+			if (context.parser != this)
+				throw new InvalidOperationException("Parser context is not associated with this parser.");
+			if (_mainRuleId == -1)
+				throw new InvalidOperationException("Main rule is not set.");
+
+			return Scan(_mainRuleId, context);
+		}
+
+		/// <summary>
+		/// Scans the input using the main rule, returning segments between matches and the matches themselves.
+		/// </summary>
+		/// <param name="input">The input text to scan.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of segments between matches and matches.</returns>
+		public IEnumerable<Or<StringSegment, ParsedRuleResultBase>> Scan(string input, object? parameter = null)
+		{
+			if (_mainRuleId == -1)
+				throw new InvalidOperationException("Main rule is not set.");
+
+			var context = new ParserContext(this, input, parameter);
+			return Scan(_mainRuleId, context);
+		}
+
+		/// <summary>
+		/// Scans the input using the specified rule, returning segments between matches and the matches themselves.
+		/// </summary>
+		/// <param name="ruleAlias">The alias for the parser rule to use.</param>
+		/// <param name="context">The parser context to use for scanning.</param>
+		/// <returns>An enumerable sequence of segments between matches and matches.</returns>
+		public IEnumerable<Or<StringSegment, ParsedRuleResultBase>> Scan(string ruleAlias, ParserContext context)
+		{
+			if (context.parser != this)
+				throw new InvalidOperationException("Parser context is not associated with this parser.");
+			if (!_rulesAliases.TryGetValue(ruleAlias, out var ruleId))
+				throw new ArgumentException("Invalid rule alias", nameof(ruleAlias));
+
+			return Scan(ruleId, context);
+		}
+
+		/// <summary>
+		/// Scans the input using the specified rule, returning segments between matches and the matches themselves.
+		/// </summary>
+		/// <param name="ruleAlias">The alias for the parser rule to use.</param>
+		/// <param name="input">The input text to scan.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of segments between matches and matches.</returns>
+		public IEnumerable<Or<StringSegment, ParsedRuleResultBase>> Scan(string ruleAlias, string input, object? parameter = null)
+		{
+			if (!_rulesAliases.TryGetValue(ruleAlias, out var ruleId))
+				throw new ArgumentException("Invalid rule alias", nameof(ruleAlias));
+
+			var context = new ParserContext(this, input, parameter);
+			return Scan(ruleId, context);
+		}
+
+		/// <summary>
+		/// Scans the input using the main rule, applying the specified factories to convert each segment into a uniform result type.
+		/// </summary>
+		/// <typeparam name="T">The type of the result.</typeparam>
+		/// <param name="context">The parser context to use for scanning.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T"/>.</param>
+		/// <returns>An enumerable sequence of converted results.</returns>
+		public IEnumerable<T> Scan<T>(ParserContext context,
+			  Func<StringSegment, T> rawFactory,
+			  Func<ParsedRuleResultBase, T> matchFactory)
+		{
+			foreach (var segment in Scan(context))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the main rule, applying the specified factories to convert each segment into a uniform result type.
+		/// </summary>
+		/// <typeparam name="T">The type of the result.</typeparam>
+		/// <param name="input">The input text to scan.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T"/>.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of converted results.</returns>
+		public IEnumerable<T> Scan<T>(string input,
+			  Func<StringSegment, T> rawFactory,
+			  Func<ParsedRuleResultBase, T> matchFactory,
+			  object? parameter = null)
+		{
+			foreach (var segment in Scan(input, parameter))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the specified rule, applying the specified factories to convert each segment into a uniform result type.
+		/// </summary>
+		/// <typeparam name="T">The type of the result.</typeparam>
+		/// <param name="ruleAlias">The alias for the parser rule to use.</param>
+		/// <param name="context">The parser context to use for scanning.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T"/>.</param>
+		/// <returns>An enumerable sequence of converted results.</returns>
+		public IEnumerable<T> Scan<T>(string ruleAlias, ParserContext context,
+			  Func<StringSegment, T> rawFactory,
+			  Func<ParsedRuleResultBase, T> matchFactory)
+		{
+			foreach (var segment in Scan(ruleAlias, context))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the specified rule, applying the specified factories to convert each segment into a uniform result type.
+		/// </summary>
+		/// <typeparam name="T">The type of the result.</typeparam>
+		/// <param name="ruleAlias">The alias for the parser rule to use.</param>
+		/// <param name="input">The input text to scan.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T"/>.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of converted results.</returns>
+		public IEnumerable<T> Scan<T>(string ruleAlias, string input,
+			  Func<StringSegment, T> rawFactory,
+			  Func<ParsedRuleResultBase, T> matchFactory,
+			  object? parameter = null)
+		{
+			foreach (var segment in Scan(ruleAlias, input, parameter))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the main rule, applying the specified factories to convert each segment into a discriminated union result.
+		/// </summary>
+		/// <typeparam name="T1">The type for raw text segments.</typeparam>
+		/// <typeparam name="T2">The type for parsed match results.</typeparam>
+		/// <param name="context">The parser context to use for scanning.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T1"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T2"/>.</param>
+		/// <returns>An enumerable sequence of <see cref="Or{T1, T2}"/> values representing either raw text or a parsed match.</returns>
+		public IEnumerable<Or<T1, T2>> Scan<T1, T2>(ParserContext context,
+			  Func<StringSegment, T1> rawFactory,
+			  Func<ParsedRuleResultBase, T2> matchFactory)
+		{
+			foreach (var segment in Scan(context))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the main rule, applying the specified factories to convert each segment into a discriminated union result.
+		/// </summary>
+		/// <typeparam name="T1">The type for raw text segments.</typeparam>
+		/// <typeparam name="T2">The type for parsed match results.</typeparam>
+		/// <param name="input">The input text to scan.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T1"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T2"/>.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of <see cref="Or{T1, T2}"/> values representing either raw text or a parsed match.</returns>
+		public IEnumerable<Or<T1, T2>> Scan<T1, T2>(string input,
+			  Func<StringSegment, T1> rawFactory,
+			  Func<ParsedRuleResultBase, T2> matchFactory,
+			  object? parameter = null)
+		{
+			foreach (var segment in Scan(input, parameter))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the specified rule, applying the specified factories to convert each segment into a discriminated union result.
+		/// </summary>
+		/// <typeparam name="T1">The type for raw text segments.</typeparam>
+		/// <typeparam name="T2">The type for parsed match results.</typeparam>
+		/// <param name="ruleAlias">The alias for the parser rule to use.</param>
+		/// <param name="context">The parser context to use for scanning.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T1"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T2"/>.</param>
+		/// <returns>An enumerable sequence of <see cref="Or{T1, T2}"/> values representing either raw text or a parsed match.</returns>
+		public IEnumerable<Or<T1, T2>> Scan<T1, T2>(string ruleAlias, ParserContext context,
+			  Func<StringSegment, T1> rawFactory,
+			  Func<ParsedRuleResultBase, T2> matchFactory)
+		{
+			foreach (var segment in Scan(ruleAlias, context))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
+		}
+
+		/// <summary>
+		/// Scans the input using the specified rule, applying the specified factories to convert each segment into a discriminated union result.
+		/// </summary>
+		/// <typeparam name="T1">The type for raw text segments.</typeparam>
+		/// <typeparam name="T2">The type for parsed match results.</typeparam>
+		/// <param name="ruleAlias">The alias for the parser rule to use.</param>
+		/// <param name="input">The input text to scan.</param>
+		/// <param name="rawFactory">Factory to convert a <see cref="StringSegment"/> into <typeparamref name="T1"/>.</param>
+		/// <param name="matchFactory">Factory to convert a <see cref="ParsedRuleResultBase"/> (parsed match) into <typeparamref name="T2"/>.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser.</param>
+		/// <returns>An enumerable sequence of <see cref="Or{T1, T2}"/> values representing either raw text or a parsed match.</returns>
+		public IEnumerable<Or<T1, T2>> Scan<T1, T2>(string ruleAlias, string input,
+			  Func<StringSegment, T1> rawFactory,
+			  Func<ParsedRuleResultBase, T2> matchFactory,
+			  object? parameter = null)
+		{
+			foreach (var segment in Scan(ruleAlias, input, parameter))
+			{
+				if (segment.VariantIndex == 0)
+					yield return rawFactory(segment.AsT1());
+				else
+					yield return matchFactory(segment.AsT2());
+			}
 		}
 	}
 }

--- a/src/RCParsing/Parser.incremental.cs
+++ b/src/RCParsing/Parser.incremental.cs
@@ -112,8 +112,14 @@ namespace RCParsing
 
 			var recovery = rule.ErrorRecovery ?? ErrorRecoveryStrategy.NoRecovery;
 			result = recovery.TryRecover(context, settings, rule, ruleContext, ruleSettings, ruleChildSettings);
-			result = result.ChangeVersion(newVersion);
-			return result;
+
+			if (result.success)
+			{
+				result = result.ChangeVersion(newVersion);
+				return result;
+			}
+
+			return ParsedRule.Fail;
 		}
 	}
 }

--- a/src/RCParsing/Parser.tokens.cs
+++ b/src/RCParsing/Parser.tokens.cs
@@ -498,6 +498,27 @@ namespace RCParsing
 		/// </remarks>
 		/// <param name="tokenPatternAlias">The alias for the token pattern to use.</param>
 		/// <param name="input">The input text to parse.</param>
+		/// <param name="parsedToken">The parsed token result. Does not include intermediate value.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser. Can be used to pass additional information to the custom token patterns.</param>
+		/// <returns><see langword="true"/> if token matches the input string; otherwise, <see langword="false"/>.</returns>
+		public bool MatchesToken(string tokenPatternAlias, string input, out ParsedElement parsedToken, object? parameter = null)
+		{
+			if (!_tokenPatternsAliases.TryGetValue(tokenPatternAlias, out var tokenPatternId))
+				throw new ArgumentException("Invalid token pattern alias", nameof(tokenPatternAlias));
+
+			parsedToken = MatchToken(tokenPatternId, input, 0,
+				input.Length, parameter, false, out _);
+			return parsedToken.success;
+		}
+
+		/// <summary>
+		/// Checks if the given input matches the specified token pattern by its alias.
+		/// </summary>
+		/// <remarks>
+		/// Does not calculates intermediate value.
+		/// </remarks>
+		/// <param name="tokenPatternAlias">The alias for the token pattern to use.</param>
+		/// <param name="input">The input text to parse.</param>
 		/// <param name="startIndex">Starting index in the input text to parse.</param>
 		/// <param name="parameter">Optional parameter to pass to the parser. Can be used to pass additional information to the custom token patterns.</param>
 		/// <returns><see langword="true"/> if token matches the input string; otherwise, <see langword="false"/>.</returns>
@@ -531,6 +552,28 @@ namespace RCParsing
 			var parsedToken = MatchToken(tokenPatternId, input, startIndex,
 				input.Length, parameter, false, out _);
 			matchedLength = parsedToken.startIndex + parsedToken.length - startIndex;
+			return parsedToken.success;
+		}
+
+		/// <summary>
+		/// Checks if the given input matches the specified token pattern by its alias.
+		/// </summary>
+		/// <remarks>
+		/// Does not calculates intermediate value.
+		/// </remarks>
+		/// <param name="tokenPatternAlias">The alias for the token pattern to use.</param>
+		/// <param name="input">The input text to parse.</param>
+		/// <param name="startIndex">Starting index in the input text to parse.</param>
+		/// <param name="parsedToken">The parsed token result. Does not include intermediate value.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser. Can be used to pass additional information to the custom token patterns.</param>
+		/// <returns><see langword="true"/> if token matches the input string; otherwise, <see langword="false"/>.</returns>
+		public bool MatchesToken(string tokenPatternAlias, string input, int startIndex, out ParsedElement parsedToken, object? parameter = null)
+		{
+			if (!_tokenPatternsAliases.TryGetValue(tokenPatternAlias, out var tokenPatternId))
+				throw new ArgumentException("Invalid token pattern alias", nameof(tokenPatternAlias));
+
+			parsedToken = MatchToken(tokenPatternId, input, startIndex,
+				input.Length, parameter, false, out _);
 			return parsedToken.success;
 		}
 
@@ -577,6 +620,29 @@ namespace RCParsing
 			var parsedToken = MatchToken(tokenPatternId, input, startIndex,
 				startIndex + length, parameter, false, out _);
 			matchedLength = parsedToken.startIndex + parsedToken.length - startIndex;
+			return parsedToken.success;
+		}
+
+		/// <summary>
+		/// Checks if the given input matches the specified token pattern by its alias.
+		/// </summary>
+		/// <remarks>
+		/// Does not calculates intermediate value.
+		/// </remarks>
+		/// <param name="tokenPatternAlias">The alias for the token pattern to use.</param>
+		/// <param name="input">The input text to parse.</param>
+		/// <param name="startIndex">Starting index in the input text to parse.</param>
+		/// <param name="length">Number of characters to parse from the input text.</param>
+		/// <param name="parsedToken">The parsed token result. Does not include intermediate value.</param>
+		/// <param name="parameter">Optional parameter to pass to the parser. Can be used to pass additional information to the custom token patterns.</param>
+		/// <returns><see langword="true"/> if token matches the input string; otherwise, <see langword="false"/>.</returns>
+		public bool MatchesToken(string tokenPatternAlias, string input, int startIndex, int length, out ParsedElement parsedToken, object? parameter = null)
+		{
+			if (!_tokenPatternsAliases.TryGetValue(tokenPatternAlias, out var tokenPatternId))
+				throw new ArgumentException("Invalid token pattern alias", nameof(tokenPatternAlias));
+
+			parsedToken = MatchToken(tokenPatternId, input, startIndex,
+				startIndex + length, parameter, false, out _);
 			return parsedToken.success;
 		}
 	}

--- a/src/RCParsing/ParserRules/RepeatParserRule.cs
+++ b/src/RCParsing/ParserRules/RepeatParserRule.cs
@@ -65,7 +65,7 @@ namespace RCParsing.ParserRules
 			ParsedRule Parse(ref ParserContext context, ref ParserSettings settings, ref ParserSettings childSettings)
 			{
 				var rules = new List<ParsedRule>();
-				var initialPosition = context.position;
+				var initialPosition = -1;
 				ParsedRule parsedRule = default;
 
 				for (int i = 0; i < this.MaxCount || this.MaxCount == -1; i++)
@@ -78,6 +78,9 @@ namespace RCParsing.ParserRules
 					if (!parsedRule.success)
 						break;
 
+					if (initialPosition == -1)
+						initialPosition = parsedRule.startIndex;
+
 					context.position = parsedRule.startIndex + parsedRule.length;
 					context.passedBarriers = parsedRule.passedBarriers;
 					parsedRule.occurency = i;
@@ -89,6 +92,9 @@ namespace RCParsing.ParserRules
 					RecordError(ref context, ref settings, $"Expected at least {MinCount} repetitions of child rule, but found {rules.Count}.");
 					return ParsedRule.Fail;
 				}
+
+				if (initialPosition == -1)
+					initialPosition = context.position;
 
 				return new ParsedRule(Id, initialPosition, context.position - initialPosition,
 					context.passedBarriers, null, rules);

--- a/src/RCParsing/ParserRules/SeparatedRepeatParserRule.cs
+++ b/src/RCParsing/ParserRules/SeparatedRepeatParserRule.cs
@@ -93,7 +93,7 @@ namespace RCParsing.ParserRules
 
 			ParsedRule Parse(ref ParserContext context, ref ParserSettings settings, ref ParserSettings childSettings)
 			{
-				var initialPosition = context.position;
+				int initialPosition = -1;
 
 				// Put some parameters from heap to stack for max performance
 				int minCount = MinCount, maxCount = MaxCount;
@@ -112,7 +112,7 @@ namespace RCParsing.ParserRules
 					// If minCount == 0 — OK: empty sequence
 					if (minCount == 0)
 					{
-						return new ParsedRule(Id, initialPosition, 0, context.passedBarriers, Array.Empty<ParsedRule>());
+						return new ParsedRule(Id, context.position, 0, context.passedBarriers, Array.Empty<ParsedRule>());
 					}
 					else
 					{
@@ -129,9 +129,10 @@ namespace RCParsing.ParserRules
 					return ParsedRule.Fail;
 				}
 
-				var elements = new List<ParsedRule>();
+				initialPosition = firstElement.startIndex;
 				int count = 1;
-				firstElement.occurency = elements.Count;
+				firstElement.occurency = 0;
+				var elements = new List<ParsedRule>();
 				elements.Add(firstElement);
 				context.position = firstElement.startIndex + firstElement.length;
 				context.passedBarriers = firstElement.passedBarriers;

--- a/src/RCParsing/ParserRules/SequenceParserRule.cs
+++ b/src/RCParsing/ParserRules/SequenceParserRule.cs
@@ -88,7 +88,7 @@ namespace RCParsing.ParserRules
 
 			ParsedRule Parse(ref ParserContext context, ref ParserSettings settings, ref ParserSettings childSettings)
 			{
-				var startIndex = context.position;
+				var initialPosition = -1;
 				ParsedRule[]? rules = null;
 
 				for (int i = 0; i < parseFunctions.Length; i++)
@@ -100,6 +100,9 @@ namespace RCParsing.ParserRules
 						return ParsedRule.Fail;
 					}
 
+					if (initialPosition == -1)
+						initialPosition = parsedRule.startIndex;
+
 					rules ??= new ParsedRule[_rules.Length];
 					parsedRule.occurency = i;
 					rules[i] = parsedRule;
@@ -108,7 +111,10 @@ namespace RCParsing.ParserRules
 					context.passedBarriers = parsedRule.passedBarriers;
 				}
 
-				return new ParsedRule(Id, startIndex, context.position - startIndex,
+				if (initialPosition == -1)
+					initialPosition = context.position;
+
+				return new ParsedRule(Id, initialPosition, context.position - initialPosition,
 					context.passedBarriers, rules);
 			};
 

--- a/src/RCParsing/PositionalFormatter.cs
+++ b/src/RCParsing/PositionalFormatter.cs
@@ -107,6 +107,28 @@ namespace RCParsing
 		{
 			Decompose(str, position, out int lineStart, out int lineLength, out int lineNumber, out int columnNumber, out int visualColumnNumber);
 
+			return Format(str, lineStart, lineLength, lineNumber, columnNumber, visualColumnNumber);
+		}
+
+		/// <summary>
+		/// Extracts a line containing a specified position in a text and formats it for display.
+		/// </summary>
+		/// <remarks>
+		/// Useful for debugging and displaying errors in a user-friendly manner.
+		/// </remarks>
+		/// <param name="str">The input text.</param>
+		/// <param name="lineStart">The zero-based index of the start of the line.</param>
+		/// <param name="lineLength">The length of the line.</param>
+		/// <param name="lineNumber">The one-based index of the line number.</param>
+		/// <param name="columnNumber">The one-based index of the column number.</param>
+		/// <param name="visualColumnNumber">The one-based index of the visual column number.</param>
+		/// <returns>
+		/// A formatted string containing the line at the specified position
+		/// along with line number and column information for the specified position.
+		/// </returns>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if the specified position is out of range for the input text.</exception>
+		public static string Format(string str, int lineStart, int lineLength, int lineNumber, int columnNumber, int visualColumnNumber)
+		{
 			string lineAndColumn = $"line {lineNumber}, column {columnNumber}";
 
 			string pointerLine;

--- a/src/RCParsing/RCParsing.csproj
+++ b/src/RCParsing/RCParsing.csproj
@@ -8,7 +8,7 @@
 
 	<PropertyGroup>
 		<PackageId>RCParsing</PackageId>
-		<Version>5.1.0</Version>
+		<Version>5.2.0</Version>
 		<Authors>Roman K.</Authors>
 		<Company>RomeCore</Company>
 		<Product>RCParsing</Product>

--- a/src/RCParsing/SemanticException.cs
+++ b/src/RCParsing/SemanticException.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RCParsing.Utils;
+
+namespace RCParsing
+{
+	/// <summary>
+	/// Represents an exception that occurs during semantic analysis (e.g. transforming <see cref="ParsedRuleResultBase"/> into a value).
+	/// </summary>
+	public class SemanticException : Exception
+	{
+		/// <summary>
+		/// Gets the parsed rule result associated with this semantic exception.
+		/// </summary>
+		public ParsedRuleResultBase AssociatedResult { get; }
+
+		/// <summary>
+		/// Gets the original exception message that have been passed to constructor.
+		/// </summary>
+		public string OriginalMessage { get; }
+
+		/// <summary>
+		/// Gets the children exceptions associated with this semantic exception.
+		/// </summary>
+		public IReadOnlyList<SemanticException> Children { get; }
+
+		public SemanticException(ParsedRuleResultBase result, string message, Exception? inner = null) :
+			base(FormatMessage(result, message, Enumerable.Empty<SemanticException>()), inner)
+		{
+			AssociatedResult = result;
+			OriginalMessage = message;
+			Children = Array.Empty<SemanticException>();
+		}
+
+		public SemanticException(ParsedRuleResultBase result, string message, params SemanticException[] children) :
+			base(FormatMessage(result, message, children))
+		{
+			AssociatedResult = result;
+			OriginalMessage = message;
+			Children = children.AsReadOnlyList();
+		}
+
+		public SemanticException(ParsedRuleResultBase result, string message, Exception? inner, params SemanticException[] children) :
+			base(FormatMessage(result, message, children), inner)
+		{
+			AssociatedResult = result;
+			OriginalMessage = message;
+			Children = children.AsReadOnlyList();
+		}
+
+		public SemanticException(ParsedRuleResultBase result, string message, IEnumerable<SemanticException> children) :
+			base(FormatMessage(result, message, children))
+		{
+			AssociatedResult = result;
+			OriginalMessage = message;
+			Children = children.AsReadOnlyList();
+		}
+
+		public SemanticException(ParsedRuleResultBase result, string message, Exception? inner, IEnumerable<SemanticException> children) :
+			base(FormatMessage(result, message, children), inner)
+		{
+			AssociatedResult = result;
+			OriginalMessage = message;
+			Children = children.AsReadOnlyList();
+		}
+
+		private static string FormatMessage(ParsedRuleResultBase result, string message, IEnumerable<SemanticException> children)
+		{
+			var sb = new StringBuilder();
+
+			sb.Append("A semantic error occurred: ");
+			sb.AppendLine(message);
+			sb.AppendLine();
+
+			var input = result.Context.input;
+			if (result.Length is 0 or 1)
+			{
+				PositionalFormatter.Decompose(input, result.StartIndex,
+					out int lineStart, out int lineLength, out int lineNumber, out int columnNumber, out int visualColumnNumber,
+					result.Context.parser.MainSettings.tabSize);
+
+				sb.AppendLine("Location:");
+
+				string lineAndColumn = $"line {lineNumber}, column {columnNumber}";
+				string pointerLine;
+				if (visualColumnNumber <= lineAndColumn.Length + 2)
+					pointerLine = new string(' ', visualColumnNumber - 1) + '^' + ' ' + lineAndColumn;
+				else
+					pointerLine = new string(' ', visualColumnNumber - 2 - lineAndColumn.Length) + lineAndColumn + ' ' + '^';
+
+				sb.AppendLine(input.Substring(lineStart, lineLength));
+				sb.AppendLine(pointerLine);
+			}
+			else
+			{
+				PositionalFormatter.Decompose(input, result.StartIndex,
+					out int lineStart1, out int lineLength1, out int lineNumber1, out int columnNumber1, out int visualColumnNumber1,
+					result.Context.parser.MainSettings.tabSize);
+
+				PositionalFormatter.Decompose(input, result.EndIndex - 1,
+					out int lineStart2, out int lineLength2, out int lineNumber2, out int columnNumber2, out int visualColumnNumber2,
+					result.Context.parser.MainSettings.tabSize);
+
+				sb.AppendLine("Location:");
+
+				if (lineNumber1 == lineNumber2)
+				{
+					// At the same line
+					string lineAndColumn = $"line {lineNumber1}, column {columnNumber1}, length {result.Length}";
+					string pointerLine;
+					if (visualColumnNumber1 <= lineAndColumn.Length + 2)
+						pointerLine = new string(' ', visualColumnNumber1 - 1) + new string('^', result.Length) + ' ' + lineAndColumn;
+					else
+						pointerLine = new string(' ', visualColumnNumber1 - 2 - lineAndColumn.Length) + lineAndColumn + ' ' + new string('^', result.Length);
+
+					sb.AppendLine(input.Substring(lineStart1, lineLength1));
+					sb.AppendLine(pointerLine);
+				}
+				else
+				{
+					// At different lines
+					sb.Append(lineNumber1.ToString().PadLeft(6) + ": ");
+					sb.AppendLine(input.Substring(lineStart1, lineLength1));
+					sb.AppendLine(new string('^', lineLength1 - visualColumnNumber1 - 2).PadLeft(lineLength1));
+
+					if (lineNumber1 + 1 != lineNumber2)
+						sb.AppendLine("...");
+
+					sb.Append(lineNumber2.ToString().PadLeft(6) + ": ");
+					sb.AppendLine(input.Substring(lineStart2, lineLength2));
+					sb.AppendLine(new string('^', lineLength2 - visualColumnNumber2 - 2).PadRight(lineLength2));
+				}
+			}
+
+			sb.AppendLine().AppendLine("The rule that failed:");
+			sb.Append(result.Rule.ToString());
+
+			var childList = children.ToList();
+			if (childList.Count > 0)
+			{
+				sb.AppendLine().AppendLine("Children errors:");
+				for (int i = 0; i < childList.Count; i++)
+				{
+					if (i < childList.Count - 1)
+						sb.AppendLine(childList[i].OriginalMessage);
+					else
+						sb.Append(childList[i].OriginalMessage);
+				}
+			}
+
+			return sb.ToString();
+		}
+	}
+}

--- a/src/RCParsing/StringSegment.cs
+++ b/src/RCParsing/StringSegment.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RCParsing
+{
+	/// <summary>
+	/// Represents a segment of a string.
+	/// </summary>
+	public struct StringSegment
+	{
+		/// <summary>
+		/// Gets the source string that contains the segment.
+		/// </summary>
+		public readonly string Source { get; }
+
+		/// <summary>
+		/// Gets the starting index of the segment within the source string. The index is zero-based.
+		/// </summary>
+		public readonly int StartIndex { get; }
+
+		/// <summary>
+		/// Gets the length of the segment. The length is the number of characters from StartIndex to the end of the string.
+		/// </summary>
+		public readonly int Length { get; }
+
+		/// <summary>
+		/// Gets the end index of the segment. This is calculated as StartIndex + Length.
+		/// </summary>
+		public readonly int EndIndex => StartIndex + Length;
+
+		/// <summary>
+		/// Gets a span representing the segment.
+		/// </summary>
+		public readonly ReadOnlySpan<char> Span => Source.AsSpan(StartIndex, Length);
+
+		private string? _slice;
+		/// <summary>
+		/// Gets a copy of the segment as a new string. This is cached for future use.
+		/// </summary>
+		public string Slice => _slice ??= Span.ToString();
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="StringSegment"/> struct.
+		/// </summary>
+		/// <param name="source">The source string that this segment belongs to.</param>
+		/// <param name="startIndex">The starting index of the segment within the source string.</param>
+		/// <param name="length">The length of the segment.</param>
+		public StringSegment(string source, int startIndex, int length)
+		{
+			Source = source;
+			StartIndex = startIndex;
+			Length = length;
+			_slice = null;
+		}
+
+		public override string ToString()
+		{
+			return Slice;
+		}
+	}
+}

--- a/src/RCParsing/TokenPatterns/AnyCharTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/AnyCharTokenPattern.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+
+namespace RCParsing.TokenPatterns
+{
+	/// <summary>
+	/// Represents an any character token pattern that matches any single character and returns it as intermediate value.
+	/// </summary>
+	public class AnyCharTokenPattern : TokenPattern
+	{
+		/// <summary>
+		/// Initializes a new instance of <see cref="AnyCharTokenPattern"/> class.
+		/// </summary>
+		public AnyCharTokenPattern()
+		{
+		}
+
+		protected override HashSet<char> FirstCharsCore => new();
+		protected override bool IsFirstCharDeterministicCore => true;
+		protected override bool IsOptionalCore => false;
+
+
+
+		public override ParsedElement Match(string input, int position, int barrierPosition,
+			object? parserParameter, bool calculateIntermediateValue, ref ParsingError furthestError)
+		{
+			if (position >= barrierPosition)
+			{
+				if (position >= furthestError.position)
+					furthestError = new ParsingError(position, 0, "Cannot match any char token, position exceeds the barrier or end of input.", Id, true);
+				return ParsedElement.Fail;
+			}
+
+			return new ParsedElement(position, 1, calculateIntermediateValue ? input[position] : null);
+		}
+
+
+
+		public override bool Equals(object obj)
+		{
+			return base.Equals(obj) &&
+				   obj is AnyCharTokenPattern;
+		}
+
+		public override int GetHashCode()
+		{
+			return base.GetHashCode();
+		}
+
+		public override string ToStringOverride(int remainingDepth)
+		{
+			return "anychar";
+		}
+	}
+}

--- a/src/RCParsing/TokenPatterns/Combinators/BetweenTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/BetweenTokenPattern.cs
@@ -91,12 +91,11 @@ namespace RCParsing.TokenPatterns.Combinators
 		public override ParsedElement Match(string input, int position, int barrierPosition,
 			object? parserParameter, bool calculateIntermediateValue, ref ParsingError furthestError)
 		{
-			var initialPosition = position;
-
 			var first = _first.Match(input, position, barrierPosition, parserParameter,
 				calculateIntermediateValue: false, ref furthestError);
 			if (!first.success)
 				return ParsedElement.Fail;
+			var initialPosition = first.startIndex;
 			position = first.startIndex + first.length;
 
 			var middle = _middle.Match(input, position, barrierPosition, parserParameter,

--- a/src/RCParsing/TokenPatterns/Combinators/CaptureTextTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/CaptureTextTokenPattern.cs
@@ -65,23 +65,19 @@ namespace RCParsing.TokenPatterns.Combinators
 			if (!child.success)
 				return ParsedElement.Fail;
 
-			var initialPosition = position;
-			position = child.startIndex + child.length;
-
-			object? value = null;
 			int trimStart = Math.Min(TrimStart, child.length);
 			int trimEnd = Math.Min(TrimEnd, child.length - trimStart);
 
 			if (child.length - trimStart - trimEnd > 0)
 			{
-				value = input.Substring(child.startIndex + trimStart, child.length - trimStart - trimEnd);
+				child.intermediateValue = input.Substring(child.startIndex + trimStart, child.length - trimStart - trimEnd);
 			}
 			else
 			{
-				value = string.Empty;
+				child.intermediateValue = string.Empty;
 			}
 
-			return new ParsedElement(initialPosition, position - initialPosition, value);
+			return child;
 		}
 
 

--- a/src/RCParsing/TokenPatterns/Combinators/FirstTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/FirstTokenPattern.cs
@@ -76,12 +76,11 @@ namespace RCParsing.TokenPatterns.Combinators
 		public override ParsedElement Match(string input, int position, int barrierPosition,
 			object? parserParameter, bool calculateIntermediateValue, ref ParsingError furthestError)
 		{
-			var initialPosition = position;
-
 			var first = _first.Match(input, position, barrierPosition, parserParameter,
 				calculateIntermediateValue, ref furthestError);
 			if (!first.success)
 				return ParsedElement.Fail;
+			var initialPosition = first.startIndex;
 			position = first.startIndex + first.length;
 
 			var second = _second.Match(input, position, barrierPosition, parserParameter, false, ref furthestError);

--- a/src/RCParsing/TokenPatterns/Combinators/RepeatTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/RepeatTokenPattern.cs
@@ -71,7 +71,7 @@ namespace RCParsing.TokenPatterns.Combinators
 		{
 			if (PassageFunction == null || !calculateIntermediateValue)
 			{
-				var initialPosition = position;
+				var initialPosition = -1;
 				int count = 0;
 
 				for (int i = 0; i < MaxCount || MaxCount == -1; i++)
@@ -83,12 +83,18 @@ namespace RCParsing.TokenPatterns.Combinators
 						break;
 					}
 
+					if (initialPosition == -1)
+						initialPosition = matchedToken.startIndex;
+
 					position = matchedToken.startIndex + matchedToken.length;
 					count++;
 				}
 
 				if (count < MinCount)
 					return ParsedElement.Fail;
+
+				if (initialPosition == -1)
+					initialPosition = position;
 
 				return new ParsedElement(initialPosition, position - initialPosition);
 			}

--- a/src/RCParsing/TokenPatterns/Combinators/ReturnTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/ReturnTokenPattern.cs
@@ -49,13 +49,11 @@ namespace RCParsing.TokenPatterns.Combinators
 				return _child.Match(input, position, barrierPosition, parserParameter,
 					false, ref furthestError);
 
-			var initialPosition = position;
 			var child = _child.Match(input, position, barrierPosition, parserParameter,
 				false, ref furthestError);
 			if (!child.success)
 				return ParsedElement.Fail;
-			position = child.startIndex + child.length;
-			return new ParsedElement(initialPosition, position - initialPosition, Value);
+			return new ParsedElement(child.startIndex, child.length, Value);
 		}
 
 

--- a/src/RCParsing/TokenPatterns/Combinators/SecondTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/SecondTokenPattern.cs
@@ -75,12 +75,11 @@ namespace RCParsing.TokenPatterns.Combinators
 		public override ParsedElement Match(string input, int position, int barrierPosition,
 			object? parserParameter, bool calculateIntermediateValue, ref ParsingError furthestError)
 		{
-			var initialPosition = position;
-
 			var first = _first.Match(input, position, barrierPosition, parserParameter,
 				false, ref furthestError);
 			if (!first.success)
 				return ParsedElement.Fail;
+			var initialPosition = first.startIndex;
 			position = first.startIndex + first.length;
 
 			var second = _second.Match(input, position, barrierPosition, parserParameter,

--- a/src/RCParsing/TokenPatterns/Combinators/SeparatedRepeatTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/SeparatedRepeatTokenPattern.cs
@@ -108,13 +108,14 @@ namespace RCParsing.TokenPatterns.Combinators
 			if (maxCount == 0)
 				return new ParsedElement(position, 0, null);
 
-			var initialPosition = position;
+			var initialPosition = -1;
 			var firstElement = _token.Match(input, position, barrierPosition, parserParameter,
 				false, ref furthestError);
+
 			if (!firstElement.success)
 			{
 				if (minCount == 0)
-					return new ParsedElement(initialPosition, position - initialPosition);
+					return new ParsedElement(position, 0);
 				else
 					return ParsedElement.Fail;
 			}
@@ -123,6 +124,7 @@ namespace RCParsing.TokenPatterns.Combinators
 				return ParsedElement.Fail;
 
 			int count = 1;
+			initialPosition = firstElement.startIndex;
 			position = firstElement.startIndex + firstElement.length;
 
 			while (maxCount == -1 || count < maxCount || (allowTrailing && count == maxCount))

--- a/src/RCParsing/TokenPatterns/Combinators/SequenceTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/SequenceTokenPattern.cs
@@ -86,7 +86,7 @@ namespace RCParsing.TokenPatterns.Combinators
 		{
 			if (calculateIntermediateValue && PassageFunction != null)
 			{
-				var initialPosition = position;
+				var initialPosition = -1;
 				object?[]? intermediateValues = null;
 
 				for (int i = 0; i < _patterns.Length; i++)
@@ -96,18 +96,23 @@ namespace RCParsing.TokenPatterns.Combinators
 					if (!token.success)
 						return ParsedElement.Fail;
 
+					if (initialPosition == -1)
+						initialPosition = token.startIndex;
+
 					intermediateValues ??= new object?[_patterns.Length];
 					intermediateValues[i] = token.intermediateValue;
 					position = token.startIndex + token.length;
 				}
 
+				if (initialPosition == -1)
+					initialPosition = position;
 				var intermediateValue = PassageFunction(intermediateValues);
 
 				return new ParsedElement(initialPosition, position - initialPosition, intermediateValue);
 			}
 			else
 			{
-				var initialPosition = position;
+				var initialPosition = -1;
 
 				for (int i = 0; i < _patterns.Length; i++)
 				{
@@ -116,8 +121,14 @@ namespace RCParsing.TokenPatterns.Combinators
 					if (!token.success)
 						return ParsedElement.Fail;
 
+					if (initialPosition == -1)
+						initialPosition = token.startIndex;
+
 					position = token.startIndex + token.length;
 				}
+
+				if (initialPosition == -1)
+					initialPosition = position;
 
 				return new ParsedElement(initialPosition, position - initialPosition);
 			}

--- a/src/RCParsing/TokenPatterns/Combinators/SkipWhitespacesTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/Combinators/SkipWhitespacesTokenPattern.cs
@@ -42,23 +42,13 @@ namespace RCParsing.TokenPatterns.Combinators
 		public override ParsedElement Match(string input, int position, int barrierPosition,
 			object? parserParameter, bool calculateIntermediateValue, ref ParsingError furthestError)
 		{
-			var initialPosition = position;
-
 			// Skip any whitespace characters
 			while (position < barrierPosition && char.IsWhiteSpace(input[position]))
 				position++;
 
 			// Match the child pattern at the new position
-			var result = _pattern.Match(input, position, barrierPosition, parserParameter,
+			return _pattern.Match(input, position, barrierPosition, parserParameter,
 				calculateIntermediateValue, ref furthestError);
-
-			if (!result.success)
-				return ParsedElement.Fail;
-
-			// Calculate the total length including skipped whitespace
-			var totalLength = (result.startIndex + result.length) - initialPosition;
-
-			return new ParsedElement(initialPosition, totalLength, result.intermediateValue);
 		}
 
 		public override string ToStringOverride(int remainingDepth)

--- a/src/RCParsing/TokenPatterns/LiteralCharTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/LiteralCharTokenPattern.cs
@@ -52,7 +52,7 @@ namespace RCParsing.TokenPatterns
 		public override ParsedElement Match(string input, int position, int barrierPosition,
 			object? parserParameter, bool calculateIntermediateValue, ref ParsingError furthestError)
 		{
-			if (position + 1 > barrierPosition)
+			if (position >= barrierPosition)
 			{
 				return ParsedElement.Fail;
 			}

--- a/src/RCParsing/TokenPatterns/ParserTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/ParserTokenPattern.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RCParsing.TokenPatterns
+{
+	/// <summary>
+	/// Represents a token pattern that uses an entire <see cref="Parser"/> for matching.
+	/// </summary>
+	public class ParserTokenPattern : TokenPattern
+	{
+		/// <summary>
+		/// The parser to use for matching.
+		/// </summary>
+		public Parser MatchParser { get; }
+
+		/// <summary>
+		/// The alias for the rule to parse.
+		/// </summary>
+		public string? RuleAlias { get; }
+
+		/// <summary>
+		/// The alias for the token to parse.
+		/// </summary>
+		public string? TokenAlias { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ParserTokenPattern"/> class.
+		/// </summary>
+		/// <param name="matchParser">The parser to use for matching.</param>
+		/// <param name="ruleAlias">The alias for the rule to parse.</param>
+		/// <param name="tokenAlias">The alias for the token to parse.</param>
+		public ParserTokenPattern(Parser matchParser, string? ruleAlias = null, string? tokenAlias = null)
+		{
+			MatchParser = matchParser ?? throw new ArgumentNullException(nameof(matchParser));
+			RuleAlias = ruleAlias;
+			TokenAlias = tokenAlias;
+		}
+
+		protected override HashSet<char> FirstCharsCore => new HashSet<char>();
+		protected override bool IsFirstCharDeterministicCore => false;
+		protected override bool IsOptionalCore => true;
+
+		public override ParsedElement Match(string input, int position, int barrierPosition, object? parserParameter,
+			bool calculateIntermediateValue, ref ParsingError furthestError)
+		{
+			if (position > barrierPosition)
+			{
+				return ParsedElement.Fail;
+			}
+
+			try
+			{
+				if (RuleAlias != null || TokenAlias == null)
+				{
+					var context = new ParserContext(MatchParser, input, parserParameter)
+					{
+						position = position,
+						maxPosition = barrierPosition
+					};
+					var result = MatchParser.ParseRule(RuleAlias, context);
+					if (calculateIntermediateValue)
+						return new ParsedElement(result.StartIndex, result.Length, result.Value);
+					else
+						return new ParsedElement(result.StartIndex, result.Length, null);
+				}
+				else
+				{
+					if (calculateIntermediateValue)
+					{
+						var result = MatchParser.TryMatchToken(TokenAlias, input, position, barrierPosition - position);
+						if (!result.Success)
+							return ParsedElement.Fail;
+						if (calculateIntermediateValue)
+							return new ParsedElement(result.StartIndex, result.Length, result.IntermediateValue);
+						else
+							return new ParsedElement(result.StartIndex, result.Length, null);
+					}
+					else
+					{
+						if (MatchParser.MatchesToken(TokenAlias, input, position, barrierPosition - position, out ParsedElement matchedToken, parserParameter))
+							return matchedToken;
+						return ParsedElement.Fail;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				if (position >= furthestError.position)
+					furthestError = new ParsingError(position, 0, ex.Message, Id, true);
+				return ParsedElement.Fail;
+			}
+		}
+
+		public override string ToStringOverride(int remainingDepth)
+		{
+			if (RuleAlias != null)
+				return $"parser(rule:{RuleAlias})";
+			if (TokenAlias != null)
+				return $"parser(token:{TokenAlias})";
+			return "parser(main)";
+		}
+	}
+}

--- a/src/RCParsing/TokenPatterns/RegexTokenPattern.cs
+++ b/src/RCParsing/TokenPatterns/RegexTokenPattern.cs
@@ -84,7 +84,7 @@ namespace RCParsing.TokenPatterns
 
 		public override string ToStringOverride(int remainingDepth)
 		{
-			return $"regex '{RegexPattern}'";
+			return $"regex '{RegexPattern ?? "unknown"}'";
 		}
 
 		public override bool Equals(object? obj)

--- a/tests/RCParsing.Tests/ReplaceAllMatchesTests.cs
+++ b/tests/RCParsing.Tests/ReplaceAllMatchesTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RCParsing.Building;
+using RCParsing.ParserRules;
+using RCParsing.TokenPatterns;
+
+namespace RCParsing.Tests
+{
+	public class ReplaceAllMatchesTests
+	{
+		[Fact]
+		public void Replace_WithCustomSelector()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateToken("hello").Literal("hello");
+			builder.CreateMainRule().Token("hello");
+
+			var result = builder.Build().ReplaceAllMatches("hello world hello",
+				replacementSelector: r => "X");
+
+			Assert.Equal("X world X", result);
+		}
+
+		[Fact]
+		public void Replace_NoMatches_ReturnsOriginal()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var result = builder.Build().ReplaceAllMatches("hello world");
+			Assert.Equal("hello world", result);
+		}
+
+		[Fact]
+		public void Replace_ByRuleAlias()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateToken("num").Number<int>();
+			builder.CreateRule("value").Token("num");
+			builder.CreateMainRule().Rule("value");
+
+			var result = builder.Build().ReplaceAllMatches("value", "a 1 b 2 c",
+				replacementSelector: r => (r.GetValue<int>() * 12).ToString(CultureInfo.InvariantCulture));
+
+			Assert.Equal("a 12 b 24 c", result);
+		}
+
+		[Fact]
+		public void Replace_SequenceWithTransform_RemovesSpaces()
+		{
+			var builder = new ParserBuilder();
+			builder.Settings.SkipWhitespaces();
+
+			builder.CreateMainRule()
+				.Literal("(")
+				.Number<int>()
+				.Literal(")")
+				.Transform(v =>
+				{
+					var num = v.GetValue<int>(1);
+					return (num * 10).ToString(CultureInfo.InvariantCulture);
+				});
+
+			// SkipWhitespaces removes spaces between tokens
+			var result = builder.Build().ReplaceAllMatches("( 1 ) text ( 2 ) more ( 3 )",
+				replacementSelector: r => r.GetValue<string>());
+
+			Assert.Equal("10 text 20 more 30", result);
+		}
+
+		[Fact]
+		public void Replace_WithContext()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateToken("num").Number<int>();
+			builder.CreateMainRule().Token("num");
+
+			var parser = builder.Build();
+			var context = parser.CreateContext("x 5 y");
+
+			var result = parser.ReplaceAllMatches(context,
+				r => r.GetValue<int>().ToString(CultureInfo.InvariantCulture));
+
+			Assert.Equal("x 5 y", result);
+		}
+
+		[Fact]
+		public void Replace_WithParameter()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateMainRule()
+				.Literal("x")
+				.Transform(v =>
+				{
+					var param = v.GetParsingParameter<int>();
+					return $"x{param}";
+				});
+
+			var result = builder.Build().ReplaceAllMatches("x x", parameter: 42,
+				replacementSelector: r => r.GetValue<string>());
+
+			Assert.Equal("x42 x42", result);
+		}
+
+		[Fact]
+		public void Replace_NoOverlap()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateMainRule().Literal("aa");
+
+			var parser = builder.Build();
+
+			var result = parser.ReplaceAllMatches("aaa",
+				replacementSelector: r => "X");
+
+			Assert.Equal("Xa", result);
+		}
+
+		[Fact]
+		public void Replace_MainRuleNotSet_Throws()
+		{
+			var parser = new ParserBuilder().Build();
+			Assert.Throws<InvalidOperationException>(() => parser.ReplaceAllMatches("test"));
+		}
+
+		[Fact]
+		public void Replace_InvalidAlias_Throws()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateMainRule().Literal("a");
+			var parser = builder.Build();
+
+			Assert.Throws<ArgumentException>(() =>
+				parser.ReplaceAllMatches("nonexistent", "test", replacementSelector: r => "X"));
+		}
+
+		[Fact]
+		public void Replace_EmptyInput_ReturnsEmpty()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var result = builder.Build().ReplaceAllMatches("", replacementSelector: r => "X");
+			Assert.Empty(result);
+		}
+
+		[Fact]
+		public void Replace_WithFallbackReplacement_NullValue()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateMainRule()
+				.Literal("x")
+				.Transform(v => null); // explicitly return null
+
+			var result = builder.Build().ReplaceAllMatches("x y x",
+				fallbackReplacement: "NULL");
+
+			// Value is null -> fallbackReplacement kicks in
+			Assert.Equal("NULL y NULL", result);
+		}
+	}
+}

--- a/tests/RCParsing.Tests/ScanTests.cs
+++ b/tests/RCParsing.Tests/ScanTests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RCParsing.Building;
+using RCParsing.ParserRules;
+using RCParsing.TokenPatterns;
+
+namespace RCParsing.Tests
+{
+	/// <summary>
+	/// Tests for <see cref="Parser.Scan"/> method.
+	/// </summary>
+	public class ScanTests
+	{
+		[Fact]
+		public void Scan_BasicInterleaving()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var input = "abc 123 def 456 ghi";
+
+			var results = builder.Build().Scan(input).ToList();
+
+			// Expected: [raw("abc "), match(123), raw(" def "), match(456), raw(" ghi")]
+			Assert.Equal(5, results.Count);
+
+			Assert.Equal(0, results[0].VariantIndex); // raw
+			Assert.Equal("abc ", results[0].AsT1().Slice);
+
+			Assert.Equal(1, results[1].VariantIndex); // match
+			Assert.Equal(123, results[1].AsT2().GetValue<int>());
+
+			Assert.Equal(0, results[2].VariantIndex); // raw
+			Assert.Equal(" def ", results[2].AsT1().Slice);
+
+			Assert.Equal(1, results[3].VariantIndex); // match
+			Assert.Equal(456, results[3].AsT2().GetValue<int>());
+
+			Assert.Equal(0, results[4].VariantIndex); // raw
+			Assert.Equal(" ghi", results[4].AsT1().Slice);
+		}
+
+		[Fact]
+		public void Scan_NoMatches_ReturnsSingleRawSegment()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var input = "hello world";
+
+			var results = builder.Build().Scan(input).ToList();
+
+			Assert.Single(results);
+			Assert.Equal(0, results[0].VariantIndex); // raw
+			Assert.Equal("hello world", results[0].AsT1().Slice);
+		}
+
+		[Fact]
+		public void Scan_EntireInputMatches_ReturnsEmptyRawBeforeMatch()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var input = "12345";
+
+			var results = builder.Build().Scan(input).ToList();
+
+			// Even if whole input matches, there's an empty raw segment before the match
+			Assert.Equal(2, results.Count);
+			Assert.Equal(0, results[0].VariantIndex); // raw (empty)
+			Assert.Empty(results[0].AsT1().Slice);
+			Assert.Equal(1, results[1].VariantIndex); // match
+			Assert.Equal(12345, results[1].AsT2().GetValue<int>());
+		}
+
+		[Fact]
+		public void Scan_WithTransformation_ReturnsTransformedValues()
+		{
+			var builder = new ParserBuilder();
+			builder.Settings.SkipWhitespaces();
+
+			builder.CreateMainRule()
+				.Literal("Price:")
+				.Number<double>()
+				.LiteralChoice("USD", "EUR")
+				.Transform(v =>
+				{
+					var number = v.GetValue<double>(1);
+					var currency = v.GetValue<string>(2);
+					return $"{number.ToString(CultureInfo.InvariantCulture)} {currency}";
+				});
+
+			var input = "Text Price: 42.99 USD more Price: 99.50 EUR end";
+
+			var results = builder.Build().Scan(input).ToList();
+
+			// Expected: raw("Text "), match("42.99 USD"), raw(" more "), match("99.50 EUR"), raw(" end")
+			Assert.Equal(5, results.Count);
+
+			Assert.Equal("Text ", results[0].AsT1().Slice);
+			Assert.Equal("42.99 USD", results[1].AsT2().GetValue<string>());
+			Assert.Equal(" more ", results[2].AsT1().Slice);
+			Assert.Equal("99.5 EUR", results[3].AsT2().GetValue<string>());
+			Assert.Equal(" end", results[4].AsT1().Slice);
+		}
+
+		[Fact]
+		public void Scan_TypedOr_WithFactories_ReturnsOrUnion()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var input = "a 5 b";
+
+			// Use different types for T1 and T2 (Or disallows same types)
+			var results = builder.Build().Scan<StringSegment, int>(
+				input,
+				rawFactory: seg => seg,
+				matchFactory: match => match.GetValue<int>()
+			).ToList();
+
+			Assert.Equal(3, results.Count);
+
+			Assert.Equal(0, results[0].VariantIndex); // raw
+			Assert.Equal("a ", results[0].AsT1().Slice);
+
+			Assert.Equal(1, results[1].VariantIndex); // match
+			Assert.Equal(5, results[1].AsT2());
+
+			Assert.Equal(0, results[2].VariantIndex); // raw
+			Assert.Equal(" b", results[2].AsT1().Slice);
+		}
+
+		[Fact]
+		public void Scan_ByRuleAlias()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("num").Number<int>();
+			builder.CreateRule("value").Token("num");
+			builder.CreateMainRule().Rule("value");
+
+			var input = "abc 42 def";
+
+			var results = builder.Build().Scan("value", input).ToList();
+
+			Assert.Equal(3, results.Count);
+			Assert.Equal("abc ", results[0].AsT1().Slice);
+			Assert.Equal(1, results[1].VariantIndex);
+			Assert.Equal(42, results[1].AsT2().GetValue<int>());
+			Assert.Equal(" def", results[2].AsT1().Slice);
+		}
+
+		[Fact]
+		public void Scan_WithContext()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var parser = builder.Build();
+			var context = parser.CreateContext("x 7 y");
+
+			var results = parser.Scan(context).ToList();
+
+			Assert.Equal(3, results.Count);
+			Assert.Equal("x ", results[0].AsT1().Slice);
+			Assert.Equal(7, results[1].AsT2().GetValue<int>());
+			Assert.Equal(" y", results[2].AsT1().Slice);
+		}
+
+		[Fact]
+		public void Scan_MainRuleNotSet_Throws()
+		{
+			var parser = new ParserBuilder().Build();
+
+			Assert.Throws<InvalidOperationException>(() => parser.Scan("test"));
+		}
+
+		[Fact]
+		public void Scan_WrongContext_Throws()
+		{
+			var builder1 = new ParserBuilder();
+			builder1.CreateMainRule().Literal("a");
+			var parser1 = builder1.Build();
+
+			var builder2 = new ParserBuilder();
+			builder2.CreateMainRule().Literal("b");
+			var parser2 = builder2.Build();
+
+			var ctx = parser2.CreateContext("test");
+
+			Assert.Throws<InvalidOperationException>(() => parser1.Scan(ctx));
+		}
+
+		[Fact]
+		public void Scan_InvalidRuleAlias_Throws()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateMainRule().Literal("a");
+			var parser = builder.Build();
+
+			Assert.Throws<ArgumentException>(() => parser.Scan("nonexistent", "test"));
+		}
+
+		[Fact]
+		public void Scan_EmptyInput_ReturnsEmpty()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var results = builder.Build().Scan("").ToList();
+
+			// Empty input yields no segments at all (nothing to scan)
+			Assert.Empty(results);
+		}
+
+		[Fact]
+		public void Scan_TypedOr_FromUntypedScan_ProducesCorrectSequence()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var input = "x 10 y 20 z";
+
+			var rawResults = builder.Build().Scan(input).ToList();
+
+			// Convert manually to check the pattern
+			var typed = rawResults.Select(seg =>
+			{
+				if (seg.VariantIndex == 0)
+					return $"RAW:{seg.AsT1().Slice}";
+				else
+					return $"NUM:{seg.AsT2().GetValue<int>()}";
+			}).ToList();
+
+			Assert.Equal(5, typed.Count);
+			Assert.Equal("RAW:x ", typed[0]);
+			Assert.Equal("NUM:10", typed[1]);
+			Assert.Equal("RAW: y ", typed[2]);
+			Assert.Equal("NUM:20", typed[3]);
+			Assert.Equal("RAW: z", typed[4]);
+		}
+	}
+}

--- a/tests/RCParsing.Tests/SplitSegmentsTests.cs
+++ b/tests/RCParsing.Tests/SplitSegmentsTests.cs
@@ -1,0 +1,107 @@
+namespace RCParsing.Tests
+{
+	/// <summary>
+	/// Tests for <see cref="Parser.SplitSegments"/> method.
+	/// </summary>
+	public class SplitSegmentsTests
+	{
+		[Fact]
+		public void SplitSegments_Basic()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var input = "a 1 b 2 c";
+
+			var segments = builder.Build().SplitSegments(input).ToList();
+
+			Assert.Equal(3, segments.Count);
+			Assert.Equal("a ", segments[0].Slice);
+			Assert.Equal(" b ", segments[1].Slice);
+			Assert.Equal(" c", segments[2].Slice);
+		}
+
+		[Fact]
+		public void SplitSegments_NoMatches_ReturnsWholeInput()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var segments = builder.Build().SplitSegments("hello").ToList();
+
+			Assert.Single(segments);
+			Assert.Equal("hello", segments[0].Slice);
+		}
+
+		[Fact]
+		public void SplitSegments_ByRuleAlias()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("n").Number<int>();
+			builder.CreateRule("val").Token("n");
+			builder.CreateMainRule().Rule("val");
+
+			var segments = builder.Build().SplitSegments("val", "x 1 y").ToList();
+
+			// One match => two segments: before and after
+			Assert.Equal(2, segments.Count);
+			Assert.Equal("x ", segments[0].Slice);
+			Assert.Equal(" y", segments[1].Slice);
+		}
+
+		[Fact]
+		public void SplitSegments_WithContext()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var parser = builder.Build();
+			var context = parser.CreateContext("q 8 r");
+
+			var segments = parser.SplitSegments(context).ToList();
+
+			// One match => two segments: before and after
+			Assert.Equal(2, segments.Count);
+			Assert.Equal("q ", segments[0].Slice);
+			Assert.Equal(" r", segments[1].Slice);
+		}
+
+		[Fact]
+		public void SplitSegments_MainRuleNotSet_Throws()
+		{
+			var parser = new ParserBuilder().Build();
+
+			Assert.Throws<InvalidOperationException>(() => parser.SplitSegments("test"));
+		}
+
+		[Fact]
+		public void SplitSegments_InvalidAlias_Throws()
+		{
+			var builder = new ParserBuilder();
+			builder.CreateMainRule().Literal("a");
+			var parser = builder.Build();
+
+			Assert.Throws<ArgumentException>(() => parser.SplitSegments("nonexistent", "test"));
+		}
+
+		[Fact]
+		public void SplitSegments_EmptyInput_ReturnsEmpty()
+		{
+			var builder = new ParserBuilder();
+
+			builder.CreateToken("number").Number<int>();
+			builder.CreateMainRule().Token("number");
+
+			var segments = builder.Build().SplitSegments("").ToList();
+
+			Assert.Empty(segments);
+		}
+	}
+}

--- a/tests/RCParsing.Tests/Tokens/CombinatorTokensTests.cs
+++ b/tests/RCParsing.Tests/Tokens/CombinatorTokensTests.cs
@@ -85,7 +85,7 @@ namespace RCParsing.Tests.Tokens
 			Assert.True(result.Success);
 			Assert.Equal((double)999, result.IntermediateValue);
 
-			Assert.True(parser.MatchesToken("value", " \"hello\" ", out var matchedLength));
+			Assert.True(parser.MatchesToken("value", " \"hello\" ", out int matchedLength));
 			Assert.Equal(8, matchedLength);
 
 			Assert.True(parser.MatchesToken("value", " 999 ", out matchedLength));

--- a/tests/RCParsing.Tests/Tokens/KeywordTokenTests.cs
+++ b/tests/RCParsing.Tests/Tokens/KeywordTokenTests.cs
@@ -18,7 +18,7 @@ namespace RCParsing.Tests.Tokens
 
 			var parser = builder.Build();
 
-			Assert.True(parser.MatchesToken("1", "keyword", out var matchedLen));
+			Assert.True(parser.MatchesToken("1", "keyword", out int matchedLen));
 			Assert.Equal(7, matchedLen);
 
 			Assert.True(parser.MatchesToken("1", "KEYWORD", out matchedLen));
@@ -42,7 +42,7 @@ namespace RCParsing.Tests.Tokens
 
 			var parser = builder.Build();
 
-			Assert.True(parser.MatchesToken("1", "keyword", out var matchedLen));
+			Assert.True(parser.MatchesToken("1", "keyword", out int matchedLen));
 			Assert.Equal(7, matchedLen);
 
 			Assert.True(parser.MatchesToken("1", "KEYWORD", out matchedLen));
@@ -83,7 +83,7 @@ namespace RCParsing.Tests.Tokens
 			var parser = builder.Build();
 
 			// Russian - Cyrillic
-			Assert.True(parser.MatchesToken("1", "привет", out var matchedLen));
+			Assert.True(parser.MatchesToken("1", "привет", out int matchedLen));
 			Assert.Equal(6, matchedLen); // 6 characters in "Привет"
 			Assert.True(parser.MatchesToken("1", "ПРИВЕТ", out matchedLen));
 			Assert.Equal(6, matchedLen);
@@ -134,7 +134,7 @@ namespace RCParsing.Tests.Tokens
 			var parser = builder.Build();
 
 			// Mixed languages - token 1
-			Assert.True(parser.MatchesToken("1", "привет", out var matchedLen));
+			Assert.True(parser.MatchesToken("1", "привет", out int matchedLen));
 			Assert.Equal(6, matchedLen);
 			Assert.True(parser.MatchesToken("1", "ПРИВЕТ", out matchedLen));
 			Assert.Equal(6, matchedLen);


### PR DESCRIPTION
New features:
- Add Scan() methods returning interleaved sequence of raw text
  segments and parsed matches via Or<StringSegment, ParsedRuleResultBase>
- Add SplitSegments() methods to split input by parser rule matches
  (analogous to Regex.Split)
- Add new overloads of MatchesToken() that return ParsedElement instead
  of just matched length
- Add AnyCharTokenPattern — matches any single character
- Add ParserTokenPattern — allows nesting one parser as a token in
  another parser
- Add StringSegment struct — lightweight zero-copy string slice with
  lazy cached substring
- Add SemanticException — structured exception with AST node reference,
  source position formatting, and nested children errors
- Expose PositionalFormatter.Format() as public static method

Bug fixes:
- Fix startIndex in RepeatParserRule, SeparatedRepeatParserRule,
  SequenceParserRule and all combinator token patterns: initialPosition
  now correctly set to first child's startIndex instead of parsing start
  position, which fixes wrong offsets when SkipStrategies are used
- Fix LiteralCharTokenPattern boundary check (position >= barrierPosition)
- Fix RegexTokenPattern null-safety in ToString()
- Fix CaptureTextTokenPattern: set intermediateValue directly on child
  element instead of creating new ParsedElement
- Fix SkipWhitespacesTokenPattern: return child result directly instead
  of wrapping in a new ParsedElement with accumulated whitespace offset

DX improvements:
- Replace hard casts (T)value in ParsedRuleResultBase with soft 'is T'
  checks that throw SemanticException with detailed context instead of
  InvalidCastException
- Same for GetIntermediateValue<T>, ConvertValue<T>, GetParsingParameter<T>

Tests:
- Add ReplaceAllMatchesTests (10 test cases)
- Add ScanTests (14 test cases)
- Add SplitSegmentsTests (8 test cases)
- Update CombinatorTokensTests and KeywordTokenTests to use explicit
  out variable types